### PR TITLE
Warn that the Codespace takes a couple of minutes to build

### DIFF
--- a/eco-flow-training/docs/commandline.md
+++ b/eco-flow-training/docs/commandline.md
@@ -2,7 +2,7 @@
 
 🧭 [◀️ Part 0 · Setup](./setup.md) &nbsp;|&nbsp; [🏠 Course menu](../README.md) &nbsp;|&nbsp; **Next:** [Part 2 · Pipelines ▶️](./pipelines.md)
 
-🚀 **Start now:** [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Eco-Flow/training)
+🚀 **Start now:** [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Eco-Flow/training) — *first launch takes a couple of minutes to build.*
 
 ---
 

--- a/eco-flow-training/docs/differential.md
+++ b/eco-flow-training/docs/differential.md
@@ -2,7 +2,7 @@
 
 🧭 [◀️ Part 3 · nf-core RNA-Seq](./nfcore_rnaseq.md) &nbsp;|&nbsp; [🏠 Course menu](../README.md)
 
-🚀 **Start now:** [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Eco-Flow/training)
+🚀 **Start now:** [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Eco-Flow/training) — *first launch takes a couple of minutes to build.*
 
 ---
 

--- a/eco-flow-training/docs/hpc.md
+++ b/eco-flow-training/docs/hpc.md
@@ -2,7 +2,7 @@
 
 🧭 [◀️ Part 3 · nf-core RNA-Seq](./nfcore_rnaseq.md) &nbsp;|&nbsp; [🏠 Course menu](../README.md)
 
-🚀 **Start now:** [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Eco-Flow/training)
+🚀 **Start now:** [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Eco-Flow/training) — *first launch takes a couple of minutes to build.*
 
 ---
 

--- a/eco-flow-training/docs/nfcore_rnaseq.md
+++ b/eco-flow-training/docs/nfcore_rnaseq.md
@@ -2,7 +2,7 @@
 
 🧭 [◀️ Part 2 · Pipelines](./pipelines.md) &nbsp;|&nbsp; [🏠 Course menu](../README.md) &nbsp;|&nbsp; **Next:** [Part 4 · Differential expression ▶️](./differential.md)
 
-🚀 **Start now:** [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Eco-Flow/training)
+🚀 **Start now:** [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Eco-Flow/training) — *first launch takes a couple of minutes to build.*
 
 ---
 

--- a/eco-flow-training/docs/pipelines.md
+++ b/eco-flow-training/docs/pipelines.md
@@ -2,7 +2,7 @@
 
 🧭 [◀️ Part 1 · Command line](./commandline.md) &nbsp;|&nbsp; [🏠 Course menu](../README.md) &nbsp;|&nbsp; **Next:** [Part 3 · nf-core RNA-Seq ▶️](./nfcore_rnaseq.md)
 
-🚀 **Start now:** [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Eco-Flow/training)
+🚀 **Start now:** [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Eco-Flow/training) — *first launch takes a couple of minutes to build.*
 
 ---
 

--- a/eco-flow-training/docs/setup.md
+++ b/eco-flow-training/docs/setup.md
@@ -2,7 +2,7 @@
 
 🧭 [🏠 Course menu](../README.md) &nbsp;|&nbsp; **Next:** [Part 1 · Command line ▶️](./commandline.md)
 
-🚀 **Start now:** [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Eco-Flow/training)
+🚀 **Start now:** [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Eco-Flow/training) — *first launch takes a couple of minutes to build.*
 
 ---
 
@@ -50,6 +50,10 @@ The Codespace takes a minute or two to build the first time. When it's ready you
 <img width="800" alt="The Codespaces VS Code environment open in a browser" src="img/codespaceopen.png">
 
 ✅ **If you see this screen, you're in!** (Your file list may look slightly different — that's fine.) Spend a few minutes on the tour below before moving on.
+
+> ⏳ **Be patient on the first launch.** Building the Codespace takes **a couple of minutes** the first time (it's installing Nextflow, Java, Docker and pulling the pipeline containers). It isn't stuck — later launches are much faster.
+
+> 📖 **The course material comes with it.** These lesson pages are part of the repo, so they're right there in the Codespace under `eco-flow-training/docs/`. You can read them inside VS Code instead of switching between tabs — open a `.md` file and press `Ctrl + Shift + V` (`Cmd + Shift + V` on a Mac) for a formatted preview.
 
 > ❓ **Stuck?** If you can't reach this screen, shout out to a tutor.
 


### PR DESCRIPTION
Add a short build-time hint beside the Start now button on every lesson page, so a slow first launch doesn't look like a failure. Expand on it once in Setup, along with a note that the lesson material ships inside the Codespace (eco-flow-training/docs/) and can be previewed in VS Code.